### PR TITLE
Switch build-backend from `flit` to `hatch`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,13 +2,13 @@
 # here we specify the build-backend. For context:
 # - tools like pip and uv are example of build-frontends. Users directly
 #   interact with the frontend
-# - tools like setuptools, hatchling, scikit-build-core, meson-python are all
+# - tools like setuptools, flit, scikit-build-core, meson-python are all
 #   examples of build backends
 requires = [
-    # the version bound is recommended in the docs
-    "flit_core >=3.11,<4"
+    # the version bound follows modern conventions for license & license-files
+    "hatchling>=1.26",
 ]
-build-backend = "flit_core.buildapi"
+build-backend = "hatchling.build"
 
 [project]
 name = "pah_spec"
@@ -70,6 +70,12 @@ docs = [
 ]
 test = ["pytest"]
 dev = [{include-group = "docs"}, {include-group = "test"}]
+
+[tool.hatch.version]
+# provide instructions to the build-backend about where it should search for
+# the version number
+path = "src/pah_spec/_version.py"
+pattern = '__version__: str = "(?P<version>[^"]+)"'
 
 # configure pytest
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,26 @@ requires-python = ">=3.8"
 description = "tool for generating PAH spectra with the single photon approximation"
 readme = "README.md"
 authors = [{name = "Helena Richie", email = "helenarichie@gmail.com"}]
+classifiers = [
+  "Environment :: Console",
+  "Intended Audience :: Science/Research",
+  "Operating System :: MacOS :: MacOS X",
+  "Operating System :: POSIX :: Linux",
+  "Operating System :: Unix",
+  "Natural Language :: English",
+  "Programming Language :: C++",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3 :: Only",
+  "Programming Language :: Python :: 3.8",
+  "Programming Language :: Python :: 3.9",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
+  "Topic :: Scientific/Engineering :: Astronomy",
+  "Topic :: Scientific/Engineering :: Physics",
+]
 # we should probably add version bounds
 dependencies = [
   'astropy',

--- a/src/pah_spec/_version.py
+++ b/src/pah_spec/_version.py
@@ -1,7 +1,7 @@
 """
 Tracks the version number
 
-In the future, we may want to use the flit_scm package to automatically generate this
+In the future, we may want to use the hatch-vcs package to automatically generate this
 file based on a git-tag
 """
-__version__: str = "0.1"
+__version__: str = "0.1.0"


### PR DESCRIPTION
This switches the build-backend[^1] from `flit` to `hatch`.

## Description

>[!note]
> Honestly, the distinctions between `flit` and `hatch` aren't very significant for us (beyond the way that metadata is specified) since `pah_spec` is a pure-python package. If we were distributing python extension modules (i.e. bindings around C/C++/Fortran/Cython code), like numpy, astropy, or gracklepy the choice of build-backend becomes much more impactful.

I originally picked `flit` because it seemed slightly simpler, but it turns `hatch` provides some nice-to-have benefits:
1. `flit` requires more manual specification of files that are included/excluded in sdist/wheels (the 2 packaging formats) while `hatch` will make useful inferences based on the version control software
2. I have the distinct impression that the `hatch-vcs` plugin for dynamically setting version information from a git tag (a feature I talk about using in issue #11) has a lot more users than the analogous `flit_scm` plugin for flit. A lot more people seem invested in it

More generally, I have the impression that there are more people behind/using hatch that are invested in writing documentation and tutorials.

## Other Change

EDIT: Oh yeah, I also added classifiers to the package which will become relevant when we upload to PyPI. I just picked the standard classifiers used in the astronomy community


[^1]: A build-backend is invoked behind the scenes by your python package manager (e.g. pip). For some context, setuptools was historically the only real build-backend (for historical reasons, some of the default behaviors are somewhat more desirable). 