### PR TITLE
switch to using hatch-vcs

### DIFF
--- a/.git_archival.txt
+++ b/.git_archival.txt
@@ -1,0 +1,3 @@
+node: $Format:%H$
+node-date: $Format:%cI$
+describe-name: $Format:%(describe:tags=true,match=*[0-9]*)$

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+.git_archival.txt  export-subst

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# this is auto-generated as part of the build
+_version.py
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[codz]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,8 +5,10 @@
 # - tools like setuptools, flit, scikit-build-core, meson-python are all
 #   examples of build backends
 requires = [
-    # the version bound follows modern conventions for license & license-files
-    "hatchling>=1.26",
+  # the version bound follows modern conventions for license & license-files
+  "hatchling>=1.26",
+  # a plugin that infers the version number from git tags
+  "hatch-vcs",
 ]
 build-backend = "hatchling.build"
 
@@ -71,11 +73,25 @@ docs = [
 test = ["pytest"]
 dev = [{include-group = "docs"}, {include-group = "test"}]
 
-[tool.hatch.version]
-# provide instructions to the build-backend about where it should search for
-# the version number
-path = "src/pah_spec/_version.py"
-pattern = '__version__: str = "(?P<version>[^"]+)"'
+# hatch-specific instructions
+[tool.hatch]
+version.source = "vcs"
+# the build-system automatically generates a file with the following name
+# that includes the version
+build.hooks.vcs.version-file = "src/pah_spec/_version.py"
+
+[tool.hatch.build.targets.sdist]
+# explicitly include the _version.py file in a sdist. It is dynamically created
+# by hooks during the build-process. (We need to explicitly include it since its
+# in our .gitignore file, which hatch uses for determining sdist contents)
+artifacts = ["src/pah_spec/_version.py"]
+
+[tool.hatch.build.targets.wheel]
+# explicitly include the _version.py file in a wheel. It is dynamically created
+# by hooks during the build-process. (We need to explicitly include it since its
+# in our .gitignore file, which hatch uses for determining wheel contents)
+artifacts = ["src/pah_spec/_version.py"]
+
 
 # configure pytest
 [tool.pytest.ini_options]

--- a/src/pah_spec/_version.py
+++ b/src/pah_spec/_version.py
@@ -1,8 +1,0 @@
-"""
-Tracks the version number
-
-In the future, we may want to use the hatch-vcs package to automatically generate this
-file based on a git-tag
-"""
-
-__version__: str = "0.1.0"


### PR DESCRIPTION
This PR seeks to start using hatch-vcs to set the version number based on the git tag