### PR TITLE
fix bugs in calc_pah_energy

### DIFF
--- a/src/pah_spec/_core.py
+++ b/src/pah_spec/_core.py
@@ -414,9 +414,9 @@ class PahSpec:
                 )
 
                 f["basis_spectra"].attrs["units"] = "erg / (s cm)"
-                f["basis_spectra"].attrs[
-                    "dimensions"
-                ] = "(n_grains, n_lambda_abs, n_lambda_em)"
+                f["basis_spectra"].attrs["dimensions"] = (
+                    "(n_grains, n_lambda_abs, n_lambda_em)"
+                )
 
                 f["lambda_abs"].attrs["units"] = "microns"
                 f["lambda_abs"].attrs["description"] = "Absorbed photon wavelengths"

--- a/src/pah_spec/_core.py
+++ b/src/pah_spec/_core.py
@@ -414,9 +414,9 @@ class PahSpec:
                 )
 
                 f["basis_spectra"].attrs["units"] = "erg / (s cm)"
-                f["basis_spectra"].attrs["dimensions"] = (
-                    "(n_grains, n_lambda_abs, n_lambda_em)"
-                )
+                f["basis_spectra"].attrs[
+                    "dimensions"
+                ] = "(n_grains, n_lambda_abs, n_lambda_em)"
 
                 f["lambda_abs"].attrs["units"] = "microns"
                 f["lambda_abs"].attrs["description"] = "Absorbed photon wavelengths"
@@ -872,7 +872,7 @@ def _calc_pah_energy(grain_radius, temp_arr):
     # modes
     # Eq. 2 of Draine & Li (2001)
     if nc <= nc_cutoff:
-        energy_arr, _ = _calc_pah_energy_modes(
+        energy_arr = _calc_pah_energy_modes(
             temp_arr, nc, nh, nm_cc_ip, nm_cc_op, grain_radius
         )
 
@@ -987,7 +987,7 @@ def _calc_pah_energy_modes(temp_arr, nc, nh, nm_cc_ip, nm_cc_op, grain_radius):
         Energies of all PAH vibrational modes in order of increasing energy (in u.erg)
     """
 
-    emode_arr = calc_pah_mode_energies(grain_radius)
+    emode_arr = _calc_pah_mode_energies(grain_radius)
 
     nmodes = len(emode_arr)
 


### PR DESCRIPTION
Fixes a couple of bugs that I missed after moving `calc_pah_mode_energies()` into a standalone function in #23 

This wasn't caught in the first place since `calc_pah_energy()` isn't called in pah_spec's automatic testing, which is an issue that should be addressed (noted in #28)